### PR TITLE
Update Cargo.toml

### DIFF
--- a/captcha_oxide/Cargo.toml
+++ b/captcha_oxide/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.70.0"
 captcha_oxide_macros = { version = "0.1.0", path = "../macros" }
 reqwest = { version = "0.12", features = [
   "json",
-  "default-tls",
+  "rustls-tls",
 ], default-features = false }
 serde = { version = "1", features = ["derive"], default-features = false }
 serde_repr = { version = "0.1", default-features = false }


### PR DESCRIPTION
use rustls-tls instead default-tls

Closes #

## 🎯 Changes

This crate makes errors when to use with rquest crate.

